### PR TITLE
Hotfix handle unexpected historical data type input

### DIFF
--- a/coronapy/cli.py
+++ b/coronapy/cli.py
@@ -111,14 +111,17 @@ def country(country, chart, hist, type):
     if hist:
         country_full_name = data[0]
         with yaspin(text="Drawing a histogram of " + country, color="cyan") as sp:
-            # Handle ISO-code as country name by using country name from meta-info of countries endpoint
-            labels_hist, hist_data = get_country.get_country_hist(country_full_name, type)
+            try:
+                labels_hist, hist_data = get_country.get_country_hist(country_full_name, type)
+            except KeyError as err:
+                click.secho("\n" + str(err), bg='black', fg='red', bold=True)
+                return
             time.sleep(1)
 
         args = {'stacked': False, 'width': 100, 'no_labels': False, 'format': '{:,}',
                 'suffix': '', "vertical": False}
 
-        click.secho("Civid-19 '" + type + "' for last 20 day in " + country_full_name + ".", bg='black', fg='yellow', blink=True, bold=True)
+        click.secho("COVID-19 '" + type + "' for last 20 day in " + country_full_name + ".", bg='black', fg='yellow', blink=True, bold=True)
 
         try:
             tg.chart(colors=[91, 94], data=hist_data, args=args, labels=labels_hist)

--- a/coronapy/lib/get_country.py
+++ b/coronapy/lib/get_country.py
@@ -23,6 +23,8 @@ def get_country_hist(country, type):
     url = 'https://corona.lmao.ninja/v2/historical/' + country
     response = requests.get(url)
     data = response.json()['timeline']
+    if type not in data:
+        raise KeyError("Unsupported historical data type: " + type + ". Use either of " + str(list(data.keys())))
     dicts = data[type]
     labels = []
     hist_data = []


### PR DESCRIPTION
+ So far the error message was not informative, if historical data type was not supported by the API

+ Text formatting from `Civid-19` to `COVID-19`